### PR TITLE
fix random answer bugs 

### DIFF
--- a/inference/answer_parsing.py
+++ b/inference/answer_parsing.py
@@ -8,14 +8,15 @@ def split_string_by_options(input_string):
     return [match.strip() for match in matches[0]]
 
 
-def parse_multi_choice_response(response, all_choices, index2ans, default_answer=None):
+def parse_multi_choice_response(response, all_choices, index2ans, default_answer=None, do_strip=False):
     """
     Parse the prediction from the generated response.
     Return the predicted index e.g., A, B, C, D.
     https://github.com/MMMU-Benchmark/MMMU/blob/51ce7f3e829c16bb44bc5445782686b4c3508794/eval/eval_utils.py#L10
     """
-    for char in [",", ".", "!", "?", ";", ":", "'"]:
-        response = response.strip(char)
+    if do_strip:
+        for char in [",", ".", "!", "?", ";", ":", "'"]:
+            response = response.strip(char)
     response = " " + response + " "  # add space to avoid partial match
 
     index_ans = True

--- a/inference/demo_api_call.py
+++ b/inference/demo_api_call.py
@@ -154,19 +154,19 @@ if __name__=='__main__':
         results = [None for _ in range(df.shape[0])]
 
     all_choices = ['A', 'B', 'C', 'D']
-    index2ans = {chr(ord("A") + i): "" for i in range(4)}
+    
 
     # Prepare for multiprocessing
-    for i in range(df.shape[0]):
-        options = df.loc[i, 'option']
-        all_options = split_string_by_options(options)
-        for j in range(len(all_choices)):
-            index2ans[all_choices[j]] = all_options[j].replace(f"{all_choices[j]}.", "").strip()
-
     args_list = []
     for index in range(df.shape[0]):
+        options = df.loc[index, 'option']
+        all_options = split_string_by_options(options)
         if index not in processed_indices:  # Check if the index has already been processed
+            index2ans = {chr(ord("A") + i): "" for i in range(4)}
+            for j in range(len(all_choices)):
+               index2ans[all_choices[j]] = all_options[j].replace(f"{all_choices[j]}.", "").strip()
             args_list.append((df.loc[index], index, args, index2ans, all_choices))
+
 
     with Pool(processes=12) as pool:  # You can adjust the number of processes as needed
         results = list(tqdm(pool.imap(process_row, args_list), total=len(args_list)))

--- a/inference/demo_api_call.py
+++ b/inference/demo_api_call.py
@@ -162,7 +162,7 @@ if __name__=='__main__':
         options = df.loc[index, 'option']
         all_options = split_string_by_options(options)
         if index not in processed_indices:  # Check if the index has already been processed
-            index2ans = {chr(ord("A") + i): "" for i in range(4)}
+            index2ans = {}
             for j in range(len(all_choices)):
                index2ans[all_choices[j]] = all_options[j].replace(f"{all_choices[j]}.", "").strip()
             args_list.append((df.loc[index], index, args, index2ans, all_choices))


### PR DESCRIPTION
This pr fixes two bugs:

1. The index2ans code has a bug that different rows share the last row's index2ans. So the response answer and correct answer can't find a proper choise, which will result in random answer, as the code in parse_multi_choice_response says.

```python
      if len(candidates) == 0:  # still not get answer, randomly choose one.
          if default_answer is None:
               pred_index = random.choice(all_choices)
```

2. The answer parsing code has a bug that it will change strip the correct answer's preriod punctuation at the end， so the answer will be random because following cde doesn't work.

```python
    for index, ans in index2ans.items():
           print(f"{index}: {ans.lower()}, {response.lower()}")
           if ans.lower() in response.lower():
                candidates.append(index)
                index_ans = False
```

for example when my first row is:

> args_list[0]:('question': 'What are the men doing?', 
'audio_path': './OmniBench/mm_data/audio/2_009_four_people.mp3', 
'image_path': './OmniBench/mm_data/image/2_009_four_people.png', 
'index': 0, 
'answer': 'The man in jeans is playing a crossword puzzle.', 
'options': ['The man in jeans is taking notes from the newspaper.', 'The man in purple is reading the newspaper.', 'The man in jeans is playing a crossword puzzle.', 'The man on the table is doing a crossword puzzle.']}, 0, input_file='./OmniBench/dataset/batch-5_1142_20240817.jsonl', 

), 
{'A': 'The man in jeans is taking notes from the newspaper.', 'B': 'The man in purple is reading the newspaper.', 'C': 'The man in jeans is playing a crossword puzzle.', 'D': 'The man on the table is doing a crossword puzzle.'}, 
['A', 'B', 'C', 'D'])

because of bug1,  the index2ans for all rows will be

> index2ans:{'A': 'Yes, both feature the same music, although the audio is a comedic rendition.', 'B': 'No, the audio is a different composition entirely.', 'C': 'Yes, but the audio is from a different section of the piece.', 'D': 'No, the audio is a similar but distinctly different Beethoven symphony.'}

after fix bug1, the index2ans for this row will be

> index2ans:{'A': 'The man in jeans is taking notes from the newspaper.', 'B': 'The man in purple is reading the newspaper.', 'C': 'The man in jeans is playing a crossword puzzle.', 'D': 'The man on the table is doing a crossword puzzle.'}

because of bug2,

the correct answer will be 'The man in jeans is playing a crossword puzzle', which can not be identified because it has no dot at the end, the real answer is   'The man in jeans is playing a crossword puzzle.'